### PR TITLE
Feature/tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${fileDirname}",
+            "env": {},
+            "args": []
+        },
+        {
+            "name": "Test",
+            "type": "go",
+            "request": "launch",
+            "mode": "test",
+            "program": "${fileDirname}",
+            "env": {},
+            "args": []
+        }
+    ]
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+)
+
+var (
+	goodServer           *httptest.Server
+	goodEventuallyServer *httptest.Server
+	badServer            *httptest.Server
+	testsInit            bool  = false
+	envoyDelayTimestamp  int64 = 0
+	envoyDelayMax        int64 = 15
+)
+
+func initTestingEnv() {
+	if testsInit {
+		return
+	}
+	os.Setenv("SCUTTLE_LOGGING", "true")
+	os.Setenv("START_WITHOUT_ENVOY", "false") // If your tests never finish, this failed
+
+	// Always 200 and live envoy state
+	goodServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("{\"state\": \"LIVE\"}")) // Envoy live response
+	}))
+
+	// 503 for 5 requests, then 200 + live envoy state
+	goodEventuallyServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		timeSinceStarted := time.Now().Unix() - envoyDelayTimestamp
+		if timeSinceStarted < envoyDelayMax {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Write([]byte("{\"state\": \"LIVE\"}")) // Envoy live response
+	}))
+
+	// Always 503
+	badServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+
+	testsInit = true
+}
+
+// Tests START_WITHOUT_ENVOY works with failing envoy mock server
+func TestBlockingDisabled(t *testing.T) {
+	os.Setenv("START_WITHOUT_ENVOY", "true")
+	block("")
+	// If your tests hang and never finish, this test "failed"
+	// Also try go test -timeout <seconds>s
+}
+
+// Tests block function with working envoy mock server
+func TestBlockingEnabled(t *testing.T) {
+	initTestingEnv()
+	os.Setenv("START_WITHOUT_ENVOY", "false")
+	block(goodServer.URL)
+}
+
+// Tests block function with envoy mock server that fails for 15 seconds, then works
+func TestSlowEnvoy(t *testing.T) {
+	initTestingEnv()
+	os.Setenv("START_WITHOUT_ENVOY", "false")
+	envoyDelayTimestamp = time.Now().Unix()
+	block(goodEventuallyServer.URL)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -17,6 +17,8 @@ var (
 	envoyDelayMax        int64 = 15
 )
 
+// Sets up default env variables and mock http servers
+// Can be called multiple times, but will only init once per test session
 func initTestingEnv() {
 	if testsInit {
 		return


### PR DESCRIPTION
* Added unit tests, can be run with `go test -timeout=60s`
* Some unit tests don't 'fail' but will timeout (e.g. testing scuttle's blocking until envoy starts)
* Envoy api is mocked with test http server 

I plan to add more tests after #5 is accepted, e.g. test stopping istio via quitquitquit endpoint