### PR TITLE
Added release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,29 @@
+name: Main
+
+on: push
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      
+      - name: Build
+        run: GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
+
+      ################################################
+      # Create Github release if this is a tag push
+      - name: Pack
+        run: |
+          mkdir build/artifacts 
+          zip -r -j build/artifacts/scuttle-linux-amd64.zip build/linux/amd64/
+        if: startsWith(github.ref, 'refs/tags/')
+     
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: build/artifacts/*.zip
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,10 @@ jobs:
         uses: actions/checkout@v1
       
       - name: Build
-        run: GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
+        run: |
+          go get github.com/cenk/backoff
+          go get github.com/monzo/typhon  
+          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
 
       ################################################
       # Create Github release if this is a tag push


### PR DESCRIPTION
* Linux executable builds on all pushes
* Executable is zipped and added as artifact to GitHub release on tags
* Zip of executable can be downloaded on the releases page

Tested in my own project here: https://github.com/linjmeyer/go-github-actions-tests