### PR TITLE
Add option to never kill Istio on failure. Resolves issue where main binary is unable to restart on failure. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,18 @@ will poll indefinitely with backoff, waiting for envoy to report itself as live,
 
 All signals are passed to the underlying application. Be warned that `SIGKILL` cannot be passed, so this can leave behind a orphaned process.
 
-When the application exits, as long as it does so with exit code 0, `scuttle` will instruct envoy to shut down immediately.
+When the application exits, unless `NEVER_KILL_ISTIO_ON_FAILURE` has been set and the exit code is non-zero, `scuttle` will instruct envoy to shut down immediately.
 
 ## Environment variables
 
-| Variable              | Purpose                                                                                                                                                                                                                                                                                                                                  |
-|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `ENVOY_ADMIN_API`     | This is the path to envoy's administration interface, in the format `http://127.0.0.1:9010`. If provided, `scuttle` will poll this url at `/server_info` waiting for envoy to report as `LIVE`. If provided and local (`127.0.0.1` or `localhost`), then envoy will be instructed to shut down if the application exits cleanly. |
-| `NEVER_KILL_ISTIO`    | If provided and set to `true`, `scuttle` will not instruct istio to exit under any circumstances.
-| `SCUTTLE_LOGGING`    | If provided and set to `true`, `scuttle` will log various steps to the console which is helpful for debugging |
-| `START_WITHOUT_ENVOY` | If provided and set to `true`, `scuttle` will not wait for envoy to be LIVE before starting the main application. However, it will still instruct envoy to exit.|
-| `ISTIO_QUIT_API` | If provided `scuttle` will send a POST to `/quitquitquit` at the given API.  Should be in format `http://127.0.0.1:15020`.  This is intended for Istio v1.3 and higher.  When not given, Istio will be stopped using a `pkill` command.
+| Variable                      | Purpose                                                                                                                                                                                                                                                                                                                                  |
+|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `ENVOY_ADMIN_API`             | This is the path to envoy's administration interface, in the format `http://127.0.0.1:9010`. If provided, `scuttle` will poll this url at `/server_info` waiting for envoy to report as `LIVE`. If provided and local (`127.0.0.1` or `localhost`), then envoy will be instructed to shut down if the application exits cleanly. |
+| `NEVER_KILL_ISTIO`            | If provided and set to `true`, `scuttle` will not instruct istio to exit under any circumstances.
+| `NEVER_KILL_ISTIO_ON_FAILURE` | If provided and set to `true`, `scuttle` will not instruct istio to exit if the main binary has exited with a non-zero exit code.
+| `SCUTTLE_LOGGING`             | If provided and set to `true`, `scuttle` will log various steps to the console which is helpful for debugging |
+| `START_WITHOUT_ENVOY`         | If provided and set to `true`, `scuttle` will not wait for envoy to be LIVE before starting the main application. However, it will still instruct envoy to exit.|
+| `ISTIO_QUIT_API`              | If provided `scuttle` will send a POST to `/quitquitquit` at the given API.  Should be in format `http://127.0.0.1:15020`.  This is intended for Istio v1.3 and higher.  When not given, Istio will be stopped using a `pkill` command.
 
 ## How Scuttle stops Istio
 

--- a/main.go
+++ b/main.go
@@ -90,6 +90,9 @@ func main() {
 	case config.NeverKillIstio:
 		// We're configured never to kill envoy, do nothing
 		log("NEVER_KILL_ISTIO is true, doing nothing")
+	case config.NeverKillIstioOnFailure && exitCode != 0:
+		log("NEVER_KILL_ISTIO_ON_FAILURE is true, exiting without killing Istio")
+		os.Exit(exitCode)
 	case config.IstioQuitAPI == "":
 		// We should stop istio, no istio API set.  Use PKILL
 		killIstioWithPkill()

--- a/scuttle_config.go
+++ b/scuttle_config.go
@@ -12,6 +12,7 @@ type ScuttleConfig struct {
 	IstioQuitAPI       string
 	NeverKillIstio     bool
 	IstioFallbackPkill bool
+	NeverKillIstioOnFailure bool
 }
 
 func log(message string) {
@@ -30,6 +31,7 @@ func getConfig() ScuttleConfig {
 		IstioQuitAPI:       getStringFromEnv("ISTIO_QUIT_API", "", loggingEnabled),
 		NeverKillIstio:     getBoolFromEnv("NEVER_KILL_ISTIO", false, loggingEnabled),
 		IstioFallbackPkill: getBoolFromEnv("ISTIO_FALLBACK_PKILL", false, loggingEnabled),
+		NeverKillIstioOnFailure: getBoolFromEnv("NEVER_KILL_ISTIO_ON_FAILURE", false, loggingEnabled),
 	}
 
 	return config


### PR DESCRIPTION
This PR adds configuration to tell scuttle not to kill Istio if the main binary exits with a non-zero exit code.

Scuttle used to work this way by default, and the readme states:
> When the application exits, as long as it does so with exit code 0, scuttle will instruct envoy to shut down immediately.

However, this functionality was removed earlier in the year and Envoy is killed even when the main binary has failed. This means pods which RestartOnFailure are unable to start because scuttle waits indefinitely for Istio, which it just killed.

I have added the option NEVER_KILL_ISTIO_ON_FAILURE to implement this without causing a breaking change to the 1.0 release.

I have updated the README to reflect this behaviour.