### PR TITLE
static link scuttle binary

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,13 @@ jobs:
         uses: actions/checkout@v1
       
       - name: Build
+        env:
+          CGO_ENABLED: 0
         run: |
           go get github.com/cenk/backoff
           go get github.com/monzo/typhon  
           go test -test.timeout 30s 
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
+          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
 
       ################################################
       # Create Github release if this is a tag push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ jobs:
           go get github.com/cenk/backoff
           go get github.com/monzo/typhon  
           go test -test.timeout 30s 
-          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
 
       ################################################
       # Create Github release if this is a tag push

--- a/docker/alpine/Dockerfile
+++ b/docker/alpine/Dockerfile
@@ -2,12 +2,9 @@ FROM golang AS build
 COPY . /app
 WORKDIR /app
 RUN go get -d
-RUN go build -o scuttle
+RUN CGO_ENABLED=0 go build -o scuttle
 
 FROM alpine:latest AS final
-# libc from the build stage is not the same as the alpine libc
-# create a symlink to where it expects it since they are compatable. https://stackoverflow.com/a/35613430/3105368
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 WORKDIR /app
 COPY --from=build /app/scuttle /bin/scuttle
 ENTRYPOINT [ "scuttle" ]

--- a/docker/stretch/Dockerfile
+++ b/docker/stretch/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:stretch AS build
 COPY . /app
 WORKDIR /app
 RUN go get -d
-RUN go build -o scuttle
+RUN CGO_ENABLED=0 go build -o scuttle
 
 FROM debian:stretch AS final
 WORKDIR /app


### PR DESCRIPTION
by static linking the binary, we enable scuttle to be used in places
which aren't shipping libc such as a binary in a docker scratch image.