### PR TITLE
Fixed nil dereference when Istio quitquitquit is bad URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -132,12 +132,19 @@ func killIstioWithAPI() {
 
 	url := fmt.Sprintf("%s/quitquitquit", config.IstioQuitAPI)
 	resp := typhon.NewRequest(context.Background(), "POST", url, nil).Send().Response()
-	log(fmt.Sprintf("Sent quitquitquit to Istio, status code: %d", resp.StatusCode))
-	if resp.StatusCode != 200 && config.IstioFallbackPkill {
+	responseSuccess := false
+
+	if resp.Error != nil {
+		log(fmt.Sprintf("Sent quitquitquit to Istio, error: %d", resp.Error))
+	} else {
+		log(fmt.Sprintf("Sent quitquitquit to Istio, status code: %d", resp.StatusCode))
+		responseSuccess = resp.StatusCode == 200
+	}
+
+	if !responseSuccess && config.IstioFallbackPkill {
 		log(fmt.Sprintf("quitquitquit failed, will attempt pkill method"))
 		killIstioWithPkill()
 	}
-	//ToDo: Fallback to pkill if this fails?
 }
 
 func killIstioWithPkill() {

--- a/main_test.go
+++ b/main_test.go
@@ -122,7 +122,7 @@ func TestNoQuitQuitQuitResponse(t *testing.T) {
 
 // Tests scuttle does not fail when the /quitquitquit endpoint is not a valid URL
 func TestNoQuitQuitQuitMalformattedUrl(t *testing.T) {
-	fmt.Println("Starting TestNoQuitQuitQuitResponse")
+	fmt.Println("Starting TestNoQuitQuitQuitMalformattedUrl")
 	os.Setenv("START_WITHOUT_ENVOY", "false")
 	os.Setenv("ISTIO_QUIT_API", "notaurl^^")
 	initTestingEnv()

--- a/main_test.go
+++ b/main_test.go
@@ -103,9 +103,28 @@ func TestSlowEnvoy(t *testing.T) {
 // Tests generic quit endpoints are sent
 func TestGenericQuitEndpoints(t *testing.T) {
 	fmt.Println("Starting TestGenericQuitEndpoints")
-	os.Setenv("START_WITHOUT_ENVOY", "true")
-	// URLs dont matter, just need something that will generate an HTTP response
-	os.Setenv("GENERIC_QUIT_ENDPOINTS", " https://google.com/, https://github.com/ ")
-	envoyDelayTimestamp = time.Now().Unix()
-	initAndRun(1)
+	// Valid URLs dont matter, just need something that will generate an HTTP response
+	// 127.0.0.1:1111/idontexist is to verify we don't panic if a nonexistent URL is given
+	// notaurl^^ is to verify a malformatted URL does not result in panic
+	os.Setenv("GENERIC_QUIT_ENDPOINTS", "https://google.com/, https://github.com/, 127.0.0.1:1111/idontexist, notaurl^^ ")
+	initTestingEnv()
+	killGenericEndpoints()
+}
+
+// Tests scuttle does not fail when the /quitquitquit endpoint does not return a response
+func TestNoQuitQuitQuitResponse(t *testing.T) {
+	fmt.Println("Starting TestNoQuitQuitQuitResponse")
+	os.Setenv("START_WITHOUT_ENVOY", "false")
+	os.Setenv("ISTIO_QUIT_API", "127.0.0.1:1111/idontexist")
+	initTestingEnv()
+	killIstioWithAPI()
+}
+
+// Tests scuttle does not fail when the /quitquitquit endpoint is not a valid URL
+func TestNoQuitQuitQuitMalformattedUrl(t *testing.T) {
+	fmt.Println("Starting TestNoQuitQuitQuitResponse")
+	os.Setenv("START_WITHOUT_ENVOY", "false")
+	os.Setenv("ISTIO_QUIT_API", "notaurl^^")
+	initTestingEnv()
+	killIstioWithAPI()
 }


### PR DESCRIPTION
Fixes #19

If an Istio quitquitquit variable is not a valid URL or doesn't exist (e.g. wrong IP or port) a nil reference panic is thrown.  This PR addresses that by properly added error checking and adding unit tests to verify we handle this situation safely.

