### PR TITLE
Add an optional 'WAIT_FOR_ENVOY_TIMEOUT' environment variable that al…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `scuttle` Is a wrapper application that makes it easy to run containers next to Istio sidecars.  It ensures the main application doesn't start until envoy is ready, and that the istio sidecar shuts down when the application exists.  This particularly useful for Jobs that need Istio sidecar injection, as the Istio pod would otherwise run indefinitely after the job is completed.
 
-This application, if provided an `ENVOY_ADMIN_API` environment variable, 
+This application, if provided an `ENVOY_ADMIN_API` environment variable,
 will poll indefinitely with backoff, waiting for envoy to report itself as live, implying it has loaded cluster configuration (for example from an ADS server). Only then will it execute the command provided as an argument.
 
 All signals are passed to the underlying application. Be warned that `SIGKILL` cannot be passed, so this can leave behind a orphaned process.
@@ -18,6 +18,7 @@ When the application exits, unless `NEVER_KILL_ISTIO_ON_FAILURE` has been set an
 | `NEVER_KILL_ISTIO_ON_FAILURE` | If provided and set to `true`, `scuttle` will not instruct istio to exit if the main binary has exited with a non-zero exit code.
 | `SCUTTLE_LOGGING`             | If provided and set to `true`, `scuttle` will log various steps to the console which is helpful for debugging |
 | `START_WITHOUT_ENVOY`         | If provided and set to `true`, `scuttle` will not wait for envoy to be LIVE before starting the main application. However, it will still instruct envoy to exit.|
+| `WAIT_FOR_ENVOY_TIMEOUT`      | If provided and set to a valid `time.Duration` string greater than 0 seconds, `scuttle` will wait for that amount of time before starting the main application. By default, it will wait indefinitely.|
 | `ISTIO_QUIT_API`              | If provided `scuttle` will send a POST to `/quitquitquit` at the given API.  Should be in format `http://127.0.0.1:15020`.  This is intended for Istio v1.3 and higher.  When not given, Istio will be stopped using a `pkill` command.
 | `GENERIC_QUIT_ENDPOINTS`      | If provided `scuttle` will send a POST to the URL given.  Multiple URLs are supported and must be provided as a CSV string.  Should be in format `http://myendpoint.com` or `http://myendpoint.com,https://myotherendpoint.com`.  The status code response is logged (if logging is enabled) but is not used.  A 200 is treated the same as a 404 or 500. `GENERIC_QUIT_ENDPOINTS` is handled before Istio is stopped. |
 
@@ -38,7 +39,7 @@ To enable this, set the environment variable `ISTIO_QUIT_API` to `http://127.0.0
 
 ### 1.2 and lower
 
-Versions 1.2 and lower of Istio have no supported method to stop Istio Sidecars.  As a workaround Scuttle stops Istio using the command `pkill -SIGINT pilot-agent`.  
+Versions 1.2 and lower of Istio have no supported method to stop Istio Sidecars.  As a workaround Scuttle stops Istio using the command `pkill -SIGINT pilot-agent`.
 
 To enable this, you must add `shareProcessNamespace: true` to your **Pod** definition in Kubernetes. This allows Scuttle to stop the service running on the sidecar container.
 

--- a/main.go
+++ b/main.go
@@ -169,7 +169,7 @@ func block() {
 
 	b := backoff.NewExponentialBackOff()
 	// We wait forever for envoy to start. In practice k8s will kill the pod if we take too long.
-	b.MaxElapsedTime = 0
+	b.MaxElapsedTime = config.WaitForEnvoyTimeout
 
 	_ = backoff.Retry(func() error {
 		rsp := typhon.NewRequest(context.Background(), "GET", url, nil).Send().Response()

--- a/scuttle_config.go
+++ b/scuttle_config.go
@@ -4,12 +4,14 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 )
 
 type ScuttleConfig struct {
 	LoggingEnabled          bool
 	EnvoyAdminAPI           string
 	StartWithoutEnvoy       bool
+	WaitForEnvoyTimeout     time.Duration
 	IstioQuitAPI            string
 	NeverKillIstio          bool
 	IstioFallbackPkill      bool
@@ -30,6 +32,7 @@ func getConfig() ScuttleConfig {
 		LoggingEnabled:          loggingEnabled,
 		EnvoyAdminAPI:           getStringFromEnv("ENVOY_ADMIN_API", "", loggingEnabled),
 		StartWithoutEnvoy:       getBoolFromEnv("START_WITHOUT_ENVOY", false, loggingEnabled),
+		WaitForEnvoyTimeout:     getDurationFromEnv("WAIT_FOR_ENVOY_TIMEOUT", time.Duration(0), loggingEnabled),
 		IstioQuitAPI:            getStringFromEnv("ISTIO_QUIT_API", "", loggingEnabled),
 		NeverKillIstio:          getBoolFromEnv("NEVER_KILL_ISTIO", false, loggingEnabled),
 		IstioFallbackPkill:      getBoolFromEnv("ISTIO_FALLBACK_PKILL", false, loggingEnabled),
@@ -90,4 +93,29 @@ func getBoolFromEnv(name string, defaultVal bool, logEnabled bool) bool {
 		log(fmt.Sprintf("%s: %s", name, userVal))
 	}
 	return (userVal == "true")
+}
+
+func getDurationFromEnv(name string, defaultVal time.Duration, logEnabled bool) time.Duration {
+	userVal := os.Getenv(name)
+
+	// User did not set anything, return default.
+	if userVal == "" {
+		return defaultVal
+	}
+
+	// User has set something, check it is valid.
+	if userVal != "" {
+		if duration, err := time.ParseDuration(userVal); err == nil {
+			// User gave valid option.
+			if logEnabled {
+				log(fmt.Sprintf("%s: %s", name, userVal))
+			}
+
+			return duration
+		} else if logEnabled {
+			log(fmt.Sprintf("%s: %s (Invalid value will be ignored)", name, userVal))
+		}
+	}
+
+	return defaultVal
 }


### PR DESCRIPTION
…lows scuttle to wait for a specified amount of time before finally starting the main application, rather than waiting indefinitely.