### PR TITLE
Added version logging on startup

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
           go get github.com/cenk/backoff
           go get github.com/monzo/typhon  
           go test -test.timeout 30s 
-          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle
+          GOOS=linux GOARCH=amd64 go build -o build/linux/amd64/scuttle -ldflags="-X 'main.Version=${{ steps.get_version.outputs.VERSION }}'"
       # Build Docker image
       # On tag, push Docker image
       - name: Build Docker Image
@@ -40,6 +40,7 @@ jobs:
           repository: redboxoss/scuttle
           tags: latest,${{ steps.get_version.outputs.VERSION }}
           push: ${{ startsWith(github.ref, 'refs/tags/') }}
+          build_args: VERSION=${{ steps.get_version.outputs.VERSION }}
       # On tag, Pack zip of scuttle for GitHub Release
       - name: Pack
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM golang:buster AS build
+ARG VERSION="local"
 COPY . /app
 WORKDIR /app
 RUN go get -d
 RUN go test -test.timeout 30s 
-RUN CGO_ENABLED=0 go build -o scuttle
+RUN CGO_ENABLED=0 go build -o scuttle -ldflags="-X 'main.Version=${VERSION}'"
 
 FROM scratch
 COPY --from=build /app/scuttle /scuttle

--- a/main.go
+++ b/main.go
@@ -20,12 +20,17 @@ type ServerInfo struct {
 	State string `json:"state"`
 }
 
+// Version ... Version of the binary, set to value like v1.0.0 in CI using ldflags
+var Version = "vlocal"
+
 var (
 	config ScuttleConfig
 )
 
 func main() {
 	config = getConfig()
+
+	log(fmt.Sprintf("Scuttle %s starting up", Version))
 
 	if len(os.Args) < 2 {
 		log("No arguments received, exiting")


### PR DESCRIPTION
* CI/release builds will now add the version number as a variable in the binary
* Log statement on startup added like "Scuttle v1.0.0 starting up"