### PR TITLE
Fix/exit signal hung envoy

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,7 +75,7 @@ func main() {
 			if proc == nil {
 				// Signal received before the process even started. Let's just exit.
 				log(fmt.Sprintf("Received signal '%v', exiting", sig))
-				os.Exit(1)
+				kill(1) // Attempt to stop sidecars if configured
 			} else {
 				// Proc is not null, so the child process is running and should also receive this signal
 				log(fmt.Sprintf("Received signal '%v', passing to child", sig))

--- a/main.go
+++ b/main.go
@@ -107,13 +107,13 @@ func kill(exitCode int) {
 	var logLineUnformatted = "Kill received: (Action: %s, Reason: %s, Exit Code: %d)"
 	switch {
 	case config.EnvoyAdminAPI == "":
-		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "ENVOY_ADMIN_API not set", exitCode))
+		log(fmt.Sprintf(logLineUnformatted, "Skipping Istio kill", "ENVOY_ADMIN_API not set", exitCode))
 	case !strings.Contains(config.EnvoyAdminAPI, "127.0.0.1") && !strings.Contains(config.EnvoyAdminAPI, "localhost"):
-		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "ENVOY_ADMIN_API is not a localhost or 127.0.0.1", exitCode))
+		log(fmt.Sprintf(logLineUnformatted, "Skipping Istio kill", "ENVOY_ADMIN_API is not a localhost or 127.0.0.1", exitCode))
 	case config.NeverKillIstio:
-		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "NEVER_KILL_ISTIO is true", exitCode))
+		log(fmt.Sprintf(logLineUnformatted, "Skipping Istio kill", "NEVER_KILL_ISTIO is true", exitCode))
 	case config.NeverKillIstioOnFailure && exitCode != 0:
-		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "NEVER_KILL_ISTIO_ON_FAILURE is true with", exitCode))
+		log(fmt.Sprintf(logLineUnformatted, "Skipping Istio kill", "NEVER_KILL_ISTIO_ON_FAILURE is true", exitCode))
 		os.Exit(exitCode)
 	case config.IstioQuitAPI == "":
 		// No istio API sent, fallback to Pkill method

--- a/main.go
+++ b/main.go
@@ -66,8 +66,7 @@ func main() {
 	var proc *os.Process
 
 	// Pass signals to the child process
-	// This takes os signal 2 (standard error)
-	// and passes those signals to the child process scuttle starts (proc)
+	// This takes an OS signal and passes to the child process scuttle starts (proc)
 	go func() {
 		stop := make(chan os.Signal, 2)
 		signal.Notify(stop)

--- a/main.go
+++ b/main.go
@@ -104,25 +104,25 @@ func main() {
 }
 
 func kill(exitCode int) {
+	var logLineUnformatted = "Kill received: (Action: %s, Reason: %s, Exit Code: %d)"
 	switch {
 	case config.EnvoyAdminAPI == "":
-		// We don't have an ENVOY_ADMIN_API env var, do nothing
-		log("kill called, No ENVOY_ADMIN_API, doing nothing")
+		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "ENVOY_ADMIN_API not set", exitCode))
 	case !strings.Contains(config.EnvoyAdminAPI, "127.0.0.1") && !strings.Contains(config.EnvoyAdminAPI, "localhost"):
-		// Envoy is not local; do nothing
-		log("kill called, ENVOY_ADMIN_API is not localhost or 127.0.0.1, doing nothing")
+		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "ENVOY_ADMIN_API is not a localhost or 127.0.0.1", exitCode))
 	case config.NeverKillIstio:
-		// We're configured never to kill envoy, do nothing
-		log("kill called, NEVER_KILL_ISTIO is true, doing nothing")
+		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "NEVER_KILL_ISTIO is true", exitCode))
 	case config.NeverKillIstioOnFailure && exitCode != 0:
-		log("kill called, NEVER_KILL_ISTIO_ON_FAILURE is true, exiting without killing Istio")
+		log(fmt.Sprintf(logLineUnformatted, "Doing nothing", "NEVER_KILL_ISTIO_ON_FAILURE is true with", exitCode))
 		os.Exit(exitCode)
 	case config.IstioQuitAPI == "":
 		// No istio API sent, fallback to Pkill method
+		log(fmt.Sprintf(logLineUnformatted, "Stopping Istio with pkill", "ISTIO_QUIT_API is not set", exitCode))
 		killGenericEndpoints()
 		killIstioWithPkill()
 	default:
 		// Stop istio using api
+		log(fmt.Sprintf(logLineUnformatted, "Stopping Istio with API", "ISTIO_QUIT_API is set", exitCode))
 		killGenericEndpoints()
 		killIstioWithAPI()
 	}


### PR DESCRIPTION
Fixes #34 

Scuttle captures OS signals and attempts to pass them to the child process.  If the child process has not started yet, then Scuttle just logs a message and exits without stopping sidecars.  This PR corrects that functionality.


Changes:
* Adds Scuttle's process id to logging, this is just for me to debug the issue
* Adjusted logging in the `kill` function for more clarity
* Will now attempt to stop sidecars when a signal is received but the child process hasn't started
* The signal is now included in the log, e.g. `Received signal 'interrupt', passing to child`

Examples of new log lines in `kill` function:

```
Kill received: (Action: Stopping Istio with pkill, Reason: ISTIO_QUIT_API is not set, Exit Code: 0)
Kill received: (Action: Skipping Istio kill, Reason: ENVOY_ADMIN_API is not a localhost or 127.0.0.1, Exit Code: 0)
Kill received: (Action: Skipping Istio kill, Reason: ENVOY_ADMIN_API not set, Exit Code: 0)
```

For future reference, this is how I was able to reproduce the issue:

```
go build
./scuttle sleep 999999

// In a separate terminal
kill -INT $(pidof scuttle)

// Should output something like:
2020-07-06T19:16:18Z scuttle: Scuttle vlocal starting up, pid 94901
2020-07-06T19:16:18Z scuttle: Logging is now enabled
2020-07-06T19:16:21Z scuttle: Received signal 'interrupt', passing to child
2020-07-06T19:16:21Z scuttle: kill called, ENVOY_ADMIN_API is not localhost or 127.0.0.1, doing nothing
```
