### PR TITLE
Fixing panic on WAIT_FOR_ENVOY_TIMEOUT

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 			if err == nil || errors.Is(err, context.Canceled) {
 				log("Blocking finished, Envoy has started")
 			} else if errors.Is(err, context.DeadlineExceeded) {
-				log("timeout reached while waiting for Envoy to start")
+				log("Blocking timeout reached and Envoy has not started")
 			} else {
 				panic(err.Error())
 			}

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 			if err == nil || errors.Is(err, context.Canceled) {
 				log("Blocking finished, Envoy has started")
 			} else if errors.Is(err, context.DeadlineExceeded) {
-				panic(errors.New("timeout reached while waiting for Envoy to start"))
+				log("timeout reached while waiting for Envoy to start")
 			} else {
 				panic(err.Error())
 			}


### PR DESCRIPTION
By default Scuttle waits forever for Envoy to start, you can set `WAIT_FOR_ENVOY_TIMEOUT` (#22) to tell Scuttle to start the application without Istio/Envoy after a certain amount of time.  I tried this today and Scuttle still throws a panic when the timeout is reached.

This PR changes the panic to a log line, then allows the application to start after `WAIT_FOR_ENVOY_TIMEOUT` time has been reached.  Default functionality of waiting indefinitely is not changed.