### PR TITLE
Update to allow QuitWithoutEnvoyTimeout to be set and take precedence…

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ When the application exits, unless `NEVER_KILL_ISTIO_ON_FAILURE` has been set an
 | `NEVER_KILL_ISTIO_ON_FAILURE` | If provided and set to `true`, `scuttle` will not instruct istio to exit if the main binary has exited with a non-zero exit code.
 | `SCUTTLE_LOGGING`             | If provided and set to `true`, `scuttle` will log various steps to the console which is helpful for debugging |
 | `START_WITHOUT_ENVOY`         | If provided and set to `true`, `scuttle` will not wait for envoy to be LIVE before starting the main application. However, it will still instruct envoy to exit.|
-| `WAIT_FOR_ENVOY_TIMEOUT`      | If provided and set to a valid `time.Duration` string greater than 0 seconds, `scuttle` will wait for that amount of time before starting the main application. By default, it will wait indefinitely.|
+| `WAIT_FOR_ENVOY_TIMEOUT`      | If provided and set to a valid `time.Duration` string greater than 0 seconds, `scuttle` will wait for that amount of time before starting the main application. By default, it will wait indefinitely. If `QUIT_WITHOUT_ENVOY_TIMEOUT` is set as well, it will take precedence over this variable |
 | `ISTIO_QUIT_API`              | If provided `scuttle` will send a POST to `/quitquitquit` at the given API.  Should be in format `http://127.0.0.1:15020`.  This is intended for Istio v1.3 and higher.  When not given, Istio will be stopped using a `pkill` command.
 | `GENERIC_QUIT_ENDPOINTS`      | If provided `scuttle` will send a POST to the URL given.  Multiple URLs are supported and must be provided as a CSV string.  Should be in format `http://myendpoint.com` or `http://myendpoint.com,https://myotherendpoint.com`.  The status code response is logged (if logging is enabled) but is not used.  A 200 is treated the same as a 404 or 500. `GENERIC_QUIT_ENDPOINTS` is handled before Istio is stopped. |
-| `QUIT_WITHOUT_ENVOY_TIMEOUT`  | If provided and set to a valid duration, `scuttle` will exit if Envoy does not become available before the end of the timeout. If `START_WITHOUT_ENVOY` is also set, this variable will not be taken into account |
+| `QUIT_WITHOUT_ENVOY_TIMEOUT`  | If provided and set to a valid duration, `scuttle` will exit if Envoy does not become available before the end of the timeout and not continue with the passed in executable. If `START_WITHOUT_ENVOY` is also set, this variable will not be taken into account. Also, if `WAIT_FOR_ENVOY_TIMEOUT` is set, this variable will take precedence. |
 
 ## How Scuttle stops Istio
 

--- a/main_test.go
+++ b/main_test.go
@@ -146,6 +146,7 @@ func TestWaitTillTimeoutForEnvoy(t *testing.T) {
 	fmt.Println("Starting TestWaitTillTimeoutForEnvoy")
 	os.Setenv("QUIT_WITHOUT_ENVOY_TIMEOUT", "500ms")
 	os.Setenv("ENVOY_ADMIN_API", badServer.URL)
+	initTestingEnv()
 	dur, _ := time.ParseDuration("500ms")
 	config.QuitWithoutEnvoyTimeout = dur
 	blockingCtx := waitForEnvoy()
@@ -156,13 +157,13 @@ func TestWaitTillTimeoutForEnvoy(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		t.Fatal("Context did not timeout")
 	case <-blockingCtx.Done():
-		if !errors.Is(blockingCtx.Err(), context.Canceled) {
+		if !errors.Is(blockingCtx.Err(), context.DeadlineExceeded) {
 			t.Fatalf("Context contains wrong error: %s", blockingCtx.Err())
 		}
 	}
 }
 
-// Tests scuttle will continue after WAIT_FOR_ENVOY_TIMEOUT expires and enovy is not ready
+// Tests scuttle will continue after WAIT_FOR_ENVOY_TIMEOUT expires and envoy is not ready
 func TestWaitForEnvoyTimeoutContinueWithoutEnvoy(t *testing.T) {
 	fmt.Println("Starting TestWaitForEnvoyTimeoutContinueWithoutEnvoy")
 	os.Setenv("WAIT_FOR_ENVOY_TIMEOUT", "5s")
@@ -173,7 +174,7 @@ func TestWaitForEnvoyTimeoutContinueWithoutEnvoy(t *testing.T) {
 	err := blockingCtx.Err()
 	if err == nil || !errors.Is(err, context.DeadlineExceeded) {
 		fmt.Println("TestWaitForEnvoyTimeoutContinueWithoutEnvoy err", err)
-		// Err is nil (enovy is up)
+		// Err is nil (envoy is up)
 		// or Err is set, but is not a cancellation err
 		// we expect a cancellation when the time is up
 		t.Fail()


### PR DESCRIPTION
Fixes #40

This is an attempt to allow QuitWithoutEnvoyTimeout to be used to exit scuttle with a non-zero exit code if the timeout value is reached. 

I made a few assumptions here, so let me know if these seem reasonable!

1. QUIT_WITHOUT_ENVOY_TIMEOUT with take precedence over WAIT_FOR_ENVOY_TIMEOUT if both are set 
2. QUIT_WITHOUT_ENVOY_TIMEOUT will cause scuttle to exit with a non-zero exit code because we want to consider the pod as failed if the istio proxy is unavailable


Let me know if there is a better way to solve this or if you would prefer to close this PR and handle it differently! Thanks