### PR TITLE
limiting scuttle shutdown to SIGINT signals

### DIFF
--- a/scripts/self_destruct.sh
+++ b/scripts/self_destruct.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Helper script that self destructs scuttle by finding it's process id and killing it
+# Helpful when testing signal handling
+# use:
+#       ./scuttle /bin/bash scripts/self_destruct.sh
+kill -INT $(pidof scuttle)
+while 1>0; do echo -n "." && sleep 1; done;


### PR DESCRIPTION
Fixes #44 

Scuttle listens for OS signals (SIGINT, SIGURG, etc.) and passes them to the child process.  This is needed to ensure signals sent by the node/k8s/container runtime make it to the underlying app running in the container.  If the child process has not been started yet (typically if Envoy is not up and healthy yet) then any signal will result in Scuttle exiting immediately.  That functionality is from the original fork so I'm not entirely sure why it was done that way.

Kubernetes shuts down containers by sending a `SIGINT`, then later a `SIGKILL`.  It's not possible to handle a SIGKILL, so I think prior to the child process starting we only need to listen to `SIGINT` and shutdown then.  

Changes:
* Prior to starting the child process, Scuttle will only listen for `SIGINT` signals
* After starting the child process, Scuttle will listen for any signals and pass them to the child process 
* Added helper script for testing signal handling (not sure how to unit test that)