### PR TITLE
Ignoring SIGURG in all cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -76,7 +76,11 @@ func main() {
 	go func() {
 		
 		for sig := range stop {
-			if proc == nil {
+			if sig == syscall.SIGURG {
+				// SIGURG is used by Golang for it's own purposes, ignore it as these signals
+				// are most likely "junk" from Golang not from K8s/Docker
+				log(fmt.Sprintf("Received signal '%v', ignoring", sig))
+			} else if proc == nil {
 				// Signal received before the process even started. Let's just exit.
 				log(fmt.Sprintf("Received signal '%v', exiting", sig))
 				kill(1) // Attempt to stop sidecars if configured

--- a/scripts/self_destruct.sh
+++ b/scripts/self_destruct.sh
@@ -3,5 +3,10 @@
 # Helpful when testing signal handling
 # use:
 #       ./scuttle /bin/bash scripts/self_destruct.sh
-kill -INT $(pidof scuttle)
+scuttle_pid=$(pidof scuttle)
+echo "------ Sending SIGURG, should be ignored ------ "
+kill -URG $scuttle_pid
+echo "------ Sending SIGINT, Scuttle should pass to child, child should exit, scuttle should exit ------ "
+kill -INT $scuttle_pid
+# Print "." until process ends
 while 1>0; do echo -n "." && sleep 1; done;


### PR DESCRIPTION
#44 reported that SIGURG signals were being logged by Scuttle from an unknown origin.  This was determined to be a result of the Golang runtime making custom use of that signal for its own purposes.  We tried to fix that by ensuring Scuttle didn't exit immediately when receiving the fake SIGURG signal.  

I think that helped, but Scuttle will still pass this signal into the child process after Envoy has been started.  Unfortunately this signal seems to mess with the child processes as well.  Logs below show that signal being passed into the child, then the child exiting and causing container restarts.  In particular it seems to affect Python apps, probably some others who consider that signal to be an issue as well:

```
scuttle: Received signal 'urgent I/O condition', passing to child
scuttle: Received signal 'urgent I/O condition', passing to child
scuttle: Kill received: (Action: Skipping Istio kill, Reason: NEVER_KILL_ISTIO is true, Exit Code: -1)
```

Links in #44, other Golang based apps have begun completely filtering out SIGURG as a result of this.  Its not commonly used and there is no way to determine if it's a real SIGURG or one generated by Golang for it's own use.  This PR filters out all SIGURGs (and logs them).

Tested using `kill -URG <scuttle_process_id>` and the log is: `scuttle: Received signal 'urgent I/O condition', ignoring`
