### PR TITLE
Use fixed go version for builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:buster AS build
+FROM golang:1.17-buster AS build
 ARG VERSION="local"
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
This will pin go version to the current latest minor version available.

The last release of scuttle was built using go version `1.16.3`, this PR also updates go version to `1.17.x` which fixes which includes correction for this [CVE-2021-38297](https://nvd.nist.gov/vuln/detail/CVE-2021-38297).