### PR TITLE
Update base image to golang 1.17.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-buster AS build
+FROM golang:1.17.9-buster AS build
 ARG VERSION="local"
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
This will update the golang base image version from `1.17.6` to the current latest `1.17.9`.
It introduces several security fixes for these CVEs:
* [CVE-2022-23806](https://nvd.nist.gov/vuln/detail/CVE-2022-23806)
* [CVE-2022-28327](https://nvd.nist.gov/vuln/detail/CVE-2022-28327)
* [CVE-2022-24675](https://nvd.nist.gov/vuln/detail/CVE-2022-24675)
* [CVE-2022-24921](https://nvd.nist.gov/vuln/detail/CVE-2022-24921)
* [CVE-2022-23772](https://nvd.nist.gov/vuln/detail/CVE-2022-23772)
* [CVE-2022-23773](https://nvd.nist.gov/vuln/detail/CVE-2022-23773)